### PR TITLE
Remove leftover definition

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ Django==1.3.1
 django-addons>=0.6.6
 django-ajax-selects==1.1.4
 django-authority
-django-bulk>=0.1devel
 django-celery
 django_compressor
 django-filter


### PR DESCRIPTION
Remove exrta definition for django-bulk that was overlooked
