### PR TITLE
Use the development branch of haystack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ django-staticfiles==1.2.1
 -f http://trac.transifex.org/files/deps/django-sorting-0.1.tar.gz
 -f http://trac.transifex.org/files/deps/django-threadedcomments-0.9.tar.gz
 -f http://trac.transifex.org/files/deps/userprofile-0.7-r422-correct-validation.tar.gz
--e git+https://github.com/toastdriven/django-haystack.git@master#egg=django-haystack-2.0.0_beta-py2.6-dev
+-e git+git://github.com/toastdriven/django-haystack.git@3289ab8bb410321a94608a13e2e527ddbd8f1a7e#egg=django-haystack
 -e git+git://github.com/mpessas/django-bulk.git#egg=django-bulk
 -e git+git://github.com/mpessas/django-tagging.git#egg=django-tagging
 -e git+git://github.com/jkal/django-notification.git#egg=django-notification


### PR DESCRIPTION
The previous haystack definition did not install properly (or at all for that matter).
It probably broke since it was using a tarball target and it is not present at github.

The question is: Is it ok to use the master branch for pip? And if not, do we know that the other branches in the repository will not be deleted, in order to use them?
