### PR TITLE
Added new language Bodo (brx) in Transifex.

### DIFF
--- a/transifex/languages/fixtures/all_languages.json
+++ b/transifex/languages/fixtures/all_languages.json
@@ -5223,5 +5223,24 @@
       "rule_many": "n mod 100 in 11..99",
       "nplurals": 6
     }
+  },
+  {
+    "pk": 276,
+    "model": "languages.language",
+    "fields": {
+      "rule_few": null,
+      "code_aliases": " ",
+      "code": "brx",
+      "name": "Bodo",
+      "description": "",
+      "pluralequation": "(n != 1)",
+      "rule_zero": null,
+      "rule_two": null,
+      "rule_one": "n is 1",
+      "rule_other": "everything else",
+      "specialchars": "",
+      "rule_many": null,
+      "nplurals": 2
+    }
   }
 ]


### PR DESCRIPTION
Added new language in Transifex:
Bodo (brx)

nplurals = 2 (one, other)

http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html
