### PR TITLE
Added for_user() method in Team manager to fetch all teams that a user h...

### DIFF
--- a/transifex/projects/models.py
+++ b/transifex/projects/models.py
@@ -94,11 +94,10 @@ class DefaultProjectQuerySet(models.query.QuerySet):
 
         Includes private projects.
         """
+        Team = get_model('teams', 'Team')
         return self.filter(
             Q(maintainers__in=[user]) |
-            Q(team__coordinators__in=[user]) |
-            Q(team__members__in=[user]) |
-            Q(team__reviewers__in=[user])
+            Q(team__in=Team.objects.for_user(user))
         ).distinct()
 
     def for_user(self, user):
@@ -112,11 +111,10 @@ class DefaultProjectQuerySet(models.query.QuerySet):
             projects = projects.filter(private=False)
         else:
             if not user.is_superuser:
+                Team = get_model('teams', 'Team')
                 projects = projects.exclude(
                     Q(private=True) & ~(Q(maintainers__in=[user]) |
-                    Q(team__coordinators__in=[user]) |
-                    Q(team__members__in=[user]) |
-                    Q(team__reviewers__in=[user]))).distinct()
+                    Q(team__in=Team.objects.for_user(user)))).distinct()
         return projects
 
     def public(self):

--- a/transifex/teams/models.py
+++ b/transifex/teams/models.py
@@ -29,8 +29,6 @@ class TeamManager(models.Manager):
 
     def for_user(self, user):
         return self.filter(
-            Q(project__owner=user) |
-            Q(project__maintainers__in=[user]) |
             Q(coordinators__in=[user]) |
             Q(members__in=[user]) |
             Q(reviewers__in=[user])

--- a/transifex/teams/tests/models.py
+++ b/transifex/teams/tests/models.py
@@ -28,9 +28,13 @@ class TestTeamModels(base.BaseTestCase):
     def test_teams_for_user(self):
         for user in ['reviewer', 'team_member', 'team_coordinator',
                 'maintainer']:
-            self.assertEqual(set(Team.objects.for_user(self.user[user]
-                ).values_list('pk')),
-                    set(Team.objects.filter(pk__in=[self.team.pk,
-                        self.team_private.pk]).values_list('pk'))
-            )
+            if user == 'maintainer':
+                self.assertFalse(Team.objects.for_user(self.user[user]))
+            else:
+                self.assertEqual(set(Team.objects.for_user(self.user[user]
+                    ).values_list('pk')),
+                        set(Team.objects.filter(pk__in=[self.team.pk,
+                            self.team_private.pk]).values_list('pk'))
+                )
+
 


### PR DESCRIPTION
This adds a for_user() method in Team Model Manager. This method returns all teams a user has access to as a member, coordinator, reviewer, project maintainer and owner.
