### PR TITLE
Handle '\r\n' as line separator in WIKI files.

### DIFF
--- a/transifex/resources/formats/wiki.py
+++ b/transifex/resources/formats/wiki.py
@@ -35,7 +35,8 @@ class WikiHandler(FillEmptyCompilerFactory, Handler):
     HandlerCompileError = WikiCompileError
 
     def _parse(self, is_source, lang_rules):
-        par_splitter = "\n\n"
+        self._find_linesep(self.content)
+        par_splitter = self.linesep + self.linesep
         template_open = "{{"
         template_ends = "}}"
 

--- a/transifex/resources/tests/lib/wiki.py
+++ b/transifex/resources/tests/lib/wiki.py
@@ -10,20 +10,44 @@ class TestWikiHandler(TestCase):
     def test_parse_wiki_text(self):
         handler = WikiHandler()
         handler.stringset = StringSet()
+        # Test content with '\n' as line separator
         content = "Text {{italics|is}}\n\nnew {{italics|par\n\npar}}.\n\nTers"
         handler.content = content
         handler._parse(None, None)
         self.assertEquals(len(handler.stringset), 3)
+        # Test content with '\r\n' as line separator
+        handler.stringset = StringSet()
+        content = "Text {{italics|is}}\r\n\r\nnew "\
+                "{{italics|par\r\n\r\npar}}.\r\n\r\nTers"
+        handler.content = content
+        handler._parse(None, None)
+        self.assertEquals(len(handler.stringset), 3)
 
+        # Test content with '\n' as line separator
         handler.stringset = StringSet()
         content = "Text {{italics|is}}\n\n\n\nnew {{italics|par\n\npar}}.\n\nTers"
         handler.content = content
         handler._parse(None, None)
         self.assertEquals(len(handler.stringset), 3)
-
+        # Test content with '\r\n' as line separator
         handler.stringset = StringSet()
-        content = ("Text {{italics|is}} {{bold|bold}}\n\n\n\nnew "
-                   "{{italics|par\n\npar}}.\n\nTers")
+        content = "Text {{italics|is}}\r\n\r\n\r\n\r\nnew "\
+                "{{italics|par\r\n\r\npar}}.\r\n\r\nTers"
+        handler.content = content
+        handler._parse(None, None)
+        self.assertEquals(len(handler.stringset), 3)
+
+        # Test content with '\n' as line separator
+        handler.stringset = StringSet()
+        content = ("text {{italics|is}} {{bold|bold}}\n\n\n\nnew "
+                   "{{italics|par\n\npar}}.\n\nters")
+        handler.content = content
+        handler._parse(None, None)
+        self.assertEquals(len(handler.stringset), 3)
+        # Test content with '\r\n' as line separator
+        handler.stringset = StringSet()
+        content = ("text {{italics|is}} {{bold|bold}}\r\n\r\n\r\n\r\nnew "
+                   "{{italics|par\r\n\r\npar}}.\r\n\r\nters")
         handler.content = content
         handler._parse(None, None)
         self.assertEquals(len(handler.stringset), 3)


### PR DESCRIPTION
This fix allows WIKI handler to handle '\r\n' as line separator in WIKI files.
