### PR TITLE
Rotate the transifex log after 10MB

### DIFF
--- a/transifex/settings/10-base.conf
+++ b/transifex/settings/10-base.conf
@@ -44,10 +44,12 @@ LOGGING = {
         },
         'log_to_file': {
             'level': 'DEBUG',
-            'class': 'logging.FileHandler',
+            'class': 'logging.handlers.RotatingFileHandler',
             'filename': os.path.join(LOG_PATH, 'transifex.log'),
             'mode': 'a+',
             'formatter': 'tx_file',
+	    'maxBytes': 1024 * 1024 * 10,
+            'backupCount': 3,
         },
         'log_to_stream': {
             'level': 'DEBUG',


### PR DESCRIPTION
Use a rotating file handler for the logs. The limit is 10MB, and wee keep 3 files for recordkeeping.

There is a possibilty to use a time based rotation too if needed.
