### PR TITLE
Use a rotating log file for the logs

### DIFF
--- a/transifex/settings/10-base.conf
+++ b/transifex/settings/10-base.conf
@@ -44,10 +44,11 @@ LOGGING = {
         },
         'log_to_file': {
             'level': 'DEBUG',
-            'class': 'logging.FileHandler',
+            'class': 'logging.handlers.TimedRotatingFileHandler',
             'filename': os.path.join(LOG_PATH, 'transifex.log'),
-            'mode': 'a+',
             'formatter': 'tx_file',
+            'when': 'midnight',
+            'backupCount': 15,
         },
         'log_to_stream': {
             'level': 'DEBUG',


### PR DESCRIPTION
The rotation happens at every night at midnight,
and a history of two weeks is kept.
