### PR TITLE
Fixed release urls to handle release slugs ending with '_r'.

### DIFF
--- a/transifex/releases/urls.py
+++ b/transifex/releases/urls.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from transifex.releases.feeds import ReleaseFeed, ReleaseLanguageFeed
 from transifex.releases.views import *
 
-RELEASE_URL_PARTIAL = r'r/(?P<release_slug>[-\w]+)/'
+RELEASE_URL_PARTIAL = r'^r/(?P<release_slug>[-\w]+)/'
 
 feeds = {
     'release': ReleaseFeed,


### PR DESCRIPTION
This fix handles release slugs ending with '_r'. This issue was seen when visiting URLs like https://opentranslators.transifex.net/projects/p/joomlaquiz/r/j1525_r/edit/
