### PR TITLE
Fix requirements.txt: python-Levenshtein is the correct name for the pac...

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ django-staticfiles==1.2.1
 -e git+git://github.com/jezdez/django_compressor.git@ee16af610d677a0a9b63602da6558f601f66287c#egg=django_compressor
 -e git+git://github.com/toastdriven/django-haystack.git@3289ab8bb410321a94608a13e2e527ddbd8f1a7e#egg=django-haystack
 -e git+git://github.com/mpessas/django-bulk.git#egg=django-bulk
--e git+git://github.com/mpessas/python-Levenshtein.git#egg=Levenshtein
+-e git+git://github.com/mpessas/python-Levenshtein.git#egg=python-Levenshtein
 -e git+git://github.com/mpessas/django-tagging.git#egg=django-tagging
 -e git+git://github.com/jkal/django-notification.git#egg=django-notification
 -e git+git://github.com/jkal/django-pagination.git#egg=django-pagination


### PR DESCRIPTION
This fixes the following error during running `python setup.py develop`

``` python
Reading http://pypi.python.org/simple/Levenshtein/
Couldn't find index page for 'Levenshtein' (maybe misspelled?)
Scanning index of all packages (this may take a while)
Reading http://pypi.python.org/simple/
No local packages or download links found for Levenshtein
error: Could not find suitable distribution for Requirement.parse('Levenshtein')
```
