### PR TITLE
Use Languages.objects.by_code_or_alias() to parse language codes in XLIF...

### DIFF
--- a/transifex/resources/tests/lib/xliff/translation_ar.xlf
+++ b/transifex/resources/tests/lib/xliff/translation_ar.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?><xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-  <file datatype="po" original="example.pot" source-language="en-US">
+  <file datatype="po" original="example.pot" source-language="en-us" target-language='ar'>
     <body>
       <trans-unit id="messages:1" resname="ee710ec49fd73392a62b8ab4e280e653" xml:space="preserve">
         <source>Please type in your password:</source>


### PR DESCRIPTION
This patch allows any language code accepted by Language.objects.by_code_or_alias() in an XLIFF file.
