### PR TITLE
README is now README.rst this fix sdist build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -23,7 +23,7 @@ include transifex/locale/LINGUAS
 recursive-include transifex/locale *.po
 
 # Docs
-include LICENSE README
+include LICENSE README.rst
 
 # Other
 recursive-include build-tools *


### PR DESCRIPTION
Without changing README to README.rst the python setup.py sdist
fails.
