### PR TITLE
Add a missing semicolon to Plural-Forms

### DIFF
--- a/transifex/resources/formats/pofile.py
+++ b/transifex/resources/formats/pofile.py
@@ -351,7 +351,7 @@ class GettextCompiler(PluralCompiler):
         po.encoding = self.format_encoding
         revision_date = self.resource.created.strftime("%Y-%m-%d %H:%M+0000")
         po.metadata['PO-Revision-Date'] = revision_date
-        plurals = "nplurals=%s; plural=%s" % (
+        plurals = "nplurals=%s; plural=%s;" % (
             self.language.nplurals, self.language.pluralequation
         )
         po.metadata['Plural-Forms'] = plurals


### PR DESCRIPTION
PO files generated by GNU gettext include a semicolon at the end of the Plural-Forms (see e.g. [this file](http://git.savannah.gnu.org/cgit/gettext.git/tree/gettext-tools/src/plural-table.c))

Missing semicolon breaks wxWidgets, without it plural forms cannot be parsed.
