### PR TITLE
Fix PIP requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.2.3
+Django==1.3.1
 Markdown==2.0.3
 PIL==1.1.7
 Pygments==1.3.1
@@ -19,6 +19,5 @@ httplib2==0.6.0
 polib==0.5.4
 pygooglechart==0.3.0
 python-magic==0.3.1
-transifex==1.0.0
 urlgrabber==3.1.0
 userprofile==0.7-r422-correct-validation


### PR DESCRIPTION
requirements.txt to be the correct content that would go through with command:
[code]# pip install `cat requirements`[/code]
for version 1.0
